### PR TITLE
Var bug fix

### DIFF
--- a/src/ast/selector/attribute.rs
+++ b/src/ast/selector/attribute.rs
@@ -27,7 +27,7 @@ use crate::parser::*;
 /// div[name=test] {}
 /// div[disabled,data-value="red"] {}
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SelectorAttr<'a> {
     pub name: &'a str,
     pub value: Option<&'a str>,

--- a/src/ast/selector/mod.rs
+++ b/src/ast/selector/mod.rs
@@ -91,7 +91,7 @@ impl<'a> Selector<'a> {
 
     /// `SelectorGroup` uses the underlying `join()` method of the
     /// `SelectorList`, combined via the product of the two
-    /// `SelectorGroup`'s items.  Foe example:
+    /// `SelectorGroup`'s items.  For example:
     ///
     /// ```css
     /// div, span {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,8 @@ impl<'a> BuildCss<'a> {
     }
 
     /// Add a file `path` to this build.
-    pub fn add(&mut self, path: &str) -> &Self {
+    pub fn add(&mut self, path: &str) {
         self.paths.push(path.to_owned());
-        self
     }
 
     /// Compile this [`BuildCss`] start-to-finish, applying all transforms along

--- a/src/transformers/apply_var.rs
+++ b/src/transformers/apply_var.rs
@@ -30,6 +30,9 @@ pub fn apply_var<'a>(tree: &mut Tree<'a>) {
         }
     });
 
+    let mut mixins = mixins.iter().collect::<Vec<_>>();
+    mixins.sort_by(|(x, _), (a, _)| x.len().cmp(&a.len()));
+    mixins.reverse();
     tree.transform(|rule: &mut Rule| {
         for (var, val) in mixins.iter() {
             rule.value = rule.value.replace(&format!("@{}", var), val).into();

--- a/tests/apply_var.rs
+++ b/tests/apply_var.rs
@@ -37,3 +37,24 @@ fn test_var() {
         Ok("div.open{color:#FF1111;}")
     )
 }
+
+#[test]
+fn test_var_overlapping_name() {
+    assert_matches!(
+        parse(
+            "
+            @blue: #CCCCFF;
+            @bluemore: #0000FF;
+            div.open {
+                color: @bluemore;
+            }
+        "
+        )
+        .map(|mut x| {
+            apply_var(&mut x);
+            x.flatten_tree().as_css_string()
+        })
+        .as_deref(),
+        Ok("div.open{color:#0000FF;}")
+    )
+}


### PR DESCRIPTION
* Fixed bug in `transformers::apply_var` which caused var substrings to be applied in the wrong order.
* Fixed bug in CSS output which did not order `@import` rules correctly (which must lead a document to be valid CSS).