### PR TITLE
Fix re-ordering or nested rulesets when flattened

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "procss"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/ast/tree_ruleset.rs
+++ b/src/ast/tree_ruleset.rs
@@ -224,6 +224,12 @@ impl<'a> TreeSelectorRuleset<'a> {
             match rule {
                 TreeRule::Rule(rule) => new_rules.push(rule.clone()),
                 TreeRule::Ruleset(ruleset) => {
+                    if !new_rules.is_empty() {
+                        let ruleset = SelectorRuleset(self.0.clone(), new_rules);
+                        new_rulesets.push(Ruleset::SelectorRuleset(ruleset));
+                        new_rules = vec![];
+                    }
+
                     let sub_rules = ruleset
                         .flatten_tree()
                         .into_iter()
@@ -235,7 +241,7 @@ impl<'a> TreeSelectorRuleset<'a> {
 
         if !new_rules.is_empty() {
             let ruleset = SelectorRuleset(self.0.clone(), new_rules);
-            new_rulesets.insert(0, Ruleset::SelectorRuleset(ruleset));
+            new_rulesets.push(Ruleset::SelectorRuleset(ruleset));
         }
 
         new_rulesets

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -146,3 +146,22 @@ fn test_scss_example() {
         Ok("ul{margin-left:1em;}ul li{list-style-type:none;}")
     )
 }
+
+#[test]
+fn test_nested_order_is_preserved() {
+    let complex = "
+        div {
+            & {
+                color: red;
+            }
+            color: green;
+        }
+    ";
+
+    assert_matches!(
+        parse(complex)
+            .map(|x| x.flatten_tree().as_css_string())
+            .as_deref(),
+        Ok("div{color:red;}div{color:green;}")
+    )
+}


### PR DESCRIPTION
Fixes output for `ast::Tree::flatten_tree` to preserve nested ruleset order in the resulting `ast::Css`.  This example previously would have resulted in `ref` due to the `Rule` taking precedence when flattening.

```css
div {
    & {
        color: red;
    }
    color: green;
}
```