### PR TITLE
Add dedupe transform

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -45,4 +45,4 @@ jobs:
               run: cargo build
 
             - name: Test
-              run: cargo test && cargo test --doc
+              run: cargo test --features iotest && cargo test --doc --features iotest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "basic"
 harness = false
 
 [features]
-bench = []
+iotest = []
 
 [dependencies]
 nom = "7.1.1"

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Test
 
 ```bash
 cargo clippy
-cargo test --doc
+cargo test --doc --features iotest
 cargo nextest run
 ```
 
 Bench
 
 ```bash
-cargo bench --features bench -- --save-baseline my-baseline
+cargo bench --features iotest -- --save-baseline my-baseline
 ```
 
 Generate docs (output at `./target/doc/procss/index.html`)

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -87,7 +87,7 @@ criterion_main!(overall, parser, other);
 
 // `bench` feature flag stubs out disk-accessing and other performance
 // neutering function
-#[cfg(all(not(feature = "bench"), not(debug_assertions)))]
+#[cfg(all(not(feature = "iotest"), not(debug_assertions)))]
 compile_error!(
     "Feature 'bench' must be enabled - rerun like this:\n\n    cargo bench --features bench\n\n"
 );

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -42,7 +42,7 @@ use crate::transformers;
 /// [`Css`] AST is typically generated via the
 /// [`crate::ast::Tree::flatten_tree`] method.
 #[derive(Debug)]
-pub struct Css<'a>(Vec<FlatRuleset<'a>>);
+pub struct Css<'a>(pub Vec<FlatRuleset<'a>>);
 
 impl<'a> Css<'a> {
     /// A mutable transform which walks this AST recursively, invoking `f` for
@@ -64,6 +64,11 @@ impl<'a> Css<'a> {
         Self: TransformCss<T>,
     {
         self.transform_each(&mut f)
+    }
+
+    /// Iterate over the immediate children of this Tree (non-recursive).
+    pub fn iter(&self) -> impl Iterator<Item = &'_ FlatRuleset<'a>> {
+        self.0.iter()
     }
 }
 

--- a/src/ast/flat_ruleset.rs
+++ b/src/ast/flat_ruleset.rs
@@ -11,6 +11,7 @@
 
 use super::ruleset::{Rule, Ruleset};
 use super::selector::SelectorPath;
+use super::{QualNestedRuleset, SelectorRuleset};
 use crate::transform::TransformCss;
 
 /// A flat (non-recursive) block, suitable for compatibility with modern
@@ -36,6 +37,16 @@ impl<'a> TransformCss<SelectorPath<'a>> for FlatRuleset<'a> {
             Ruleset::QualRule(_) => (),
             Ruleset::QualRuleset(_) => (),
             Ruleset::QualNestedRuleset(ruleset) => ruleset.transform_each(f),
+        }
+    }
+}
+
+impl<'a> TransformCss<SelectorRuleset<'a, Rule<'a>>> for FlatRuleset<'a> {
+    fn transform_each<F: FnMut(&mut SelectorRuleset<'a, Rule<'a>>)>(&mut self, f: &mut F) {
+        match self {
+            Ruleset::SelectorRuleset(ruleset) => f(ruleset),
+            Ruleset::QualNestedRuleset(ruleset) => ruleset.transform_each(f),
+            _ => (),
         }
     }
 }

--- a/src/ast/flat_ruleset.rs
+++ b/src/ast/flat_ruleset.rs
@@ -11,7 +11,7 @@
 
 use super::ruleset::{Rule, Ruleset};
 use super::selector::SelectorPath;
-use super::{QualNestedRuleset, SelectorRuleset};
+use super::SelectorRuleset;
 use crate::transform::TransformCss;
 
 /// A flat (non-recursive) block, suitable for compatibility with modern

--- a/src/ast/selector/attribute.rs
+++ b/src/ast/selector/attribute.rs
@@ -27,7 +27,7 @@ use crate::parser::*;
 /// div[name=test] {}
 /// div[disabled,data-value="red"] {}
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SelectorAttr<'a> {
     pub name: &'a str,
     pub value: Option<&'a str>,

--- a/src/ast/selector/combinator.rs
+++ b/src/ast/selector/combinator.rs
@@ -20,7 +20,7 @@ use crate::parser::*;
 use crate::render::*;
 
 /// A selector combinator, used to combine a list of selectors.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Combinator {
     Null,
     Sibling,

--- a/src/ast/selector/mod.rs
+++ b/src/ast/selector/mod.rs
@@ -32,7 +32,7 @@ use crate::transform::TransformCss;
 use crate::utils::*;
 
 /// A set of selector alternatives separated by `,`, for example `div, span`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Selector<'a>(MinVec<SelectorPath<'a>, 1>);
 
 impl<'a> Default for Selector<'a> {

--- a/src/ast/selector/selector_path.rs
+++ b/src/ast/selector/selector_path.rs
@@ -26,7 +26,7 @@ use crate::render::*;
 /// selector `&`, as special case `PartialCons` elimantes `tag` as a field from
 /// this first Selector, preventing the `SelectorList` from being serialized
 /// before being flattened.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SelectorPath<'a> {
     Cons(
         SelectorTerm<'a, Option<&'a str>>,

--- a/src/ast/selector/selector_term.rs
+++ b/src/ast/selector/selector_term.rs
@@ -24,7 +24,7 @@ use crate::render::*;
 
 /// A pseudo-selector component of a `Selector`, including optional argument
 /// selector (parenthesis delimited).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Pseudo<'a> {
     property: &'a str,
     value: Option<SelectorTerm<'a, Option<&'a str>>>,
@@ -61,7 +61,7 @@ enum SelType<'a> {
 /// A single compound CSS selector, parameterized over it's `tag` field such
 /// that the uniqu wildcard and self selectors can re-use the same struct and
 /// some tag-irrelevent functions can be shared between impls.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct SelectorTerm<'a, T> {
     pub id: Option<&'a str>,
     pub class: Vec<&'a str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ impl<'a> BuildCss<'a> {
     pub fn compile(&'a mut self) -> anyhow::Result<CompiledCss<'a>> {
         for path in &self.paths {
             let inpath = PathBuf::from(self.rootdir).join(path);
-            let contents = if cfg!(debug_assertions) {
+            let contents = if cfg!(feature = "iotest") {
                 "div{}".to_owned()
             } else {
                 fs::read_to_string(inpath)?
@@ -227,7 +227,7 @@ impl<'a> CompiledCss<'a> {
             );
 
             let outdir = PathBuf::from(outdir).join(outpath.parent().unwrap());
-            if !cfg!(debug_assertions) {
+            if !cfg!(feature = "iotest") {
                 fs::create_dir_all(outdir.clone()).unwrap_or_default();
                 fs::write(outdir.join(outfile), css.as_css_string())?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ impl<'a> BuildCss<'a> {
             transformers::apply_var(tree);
             let mut flat = tree.flatten_tree();
             transformers::inline_url(self.rootdir)(&mut flat);
+            transformers::dedupe(&mut flat);
             self.css.insert(path, flat);
         }
 

--- a/src/transformers/inline_url.rs
+++ b/src/transformers/inline_url.rs
@@ -18,14 +18,14 @@ use nom::sequence::delimited;
 
 use crate::ast::{Css, Rule};
 
-#[cfg(feature = "bench")]
+#[cfg(feature = "iotest")]
 mod fs {
     pub fn read_to_string(_input: &std::path::Path) -> Result<&'static str, String> {
         criterion::black_box(Ok(include_str!("../../benches/test.svg")))
     }
 }
 
-#[cfg(not(feature = "bench"))]
+#[cfg(not(feature = "iotest"))]
 mod fs {
     pub use std::fs::read_to_string;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@
 use crate::render::RenderCss;
 
 /// A wrapper around [`Vec`] which guarantees at least `N` elements.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct MinVec<T, const N: usize>([T; N], Vec<T>);
 
 impl<T, const N: usize> MinVec<T, N>

--- a/tests/dedupe.rs
+++ b/tests/dedupe.rs
@@ -1,0 +1,125 @@
+// ┌───────────────────────────────────────────────────────────────────────────┐
+// │                                                                           │
+// │  ██████╗ ██████╗  ██████╗   Copyright (C) 2022, The Prospective Company   │
+// │  ██╔══██╗██╔══██╗██╔═══██╗                                                │
+// │  ██████╔╝██████╔╝██║   ██║  This file is part of the Procss library,      │
+// │  ██╔═══╝ ██╔══██╗██║   ██║  distributed under the terms of the            │
+// │  ██║     ██║  ██║╚██████╔╝  Apache License 2.0.  The full license can     │
+// │  ╚═╝     ╚═╝  ╚═╝ ╚═════╝   be found in the LICENSE file.                 │
+// │                                                                           │
+// └───────────────────────────────────────────────────────────────────────────┘
+
+#![feature(assert_matches)]
+
+#[cfg(test)]
+use std::assert_matches::assert_matches;
+
+use procss::transformers::{self};
+use procss::{parse, RenderCss};
+
+#[test]
+fn test_advanced_mixin() {
+    let test_data =
+        "
+    div[theme=\"custom\"] {
+        @include div-theme;
+    }
+    
+    perspective-copy-menu[theme=\"custom\"],
+    .perspective-modal-theme {
+        @include perspective-modal-theme;
+    }
+    
+    @mixin div-theme {
+        @include div-theme--dimensions;
+        @include div-theme--colors;
+        @include div-theme--fonts;
+        @include div-theme--intl;
+        @include div-theme--chart;
+        @include div-theme--datagrid;
+        @include div-theme--openlayers;
+    }
+    
+    @mixin perspective-modal-theme {
+        @include div-theme--fonts;
+        @include div-theme--colors;
+        background-color: white;
+        --column-style-pos-color--content: \"add\";
+    }
+    
+    @mixin div-theme--dimensions {
+        --button--font-size: 16px;--config-button--padding: 15px 8px 6px 8px;
+        // Comment comment comment
+    }
+    
+    @mixin div-theme--colors {
+        color: #161616;
+        background-color: #f2f4f6;
+    }
+    
+    @mixin div-theme--fonts {
+        font-family: \"Open Sans\";
+        --interface-monospace--font-family: \"Roboto Mono\";
+        --button--font-family: \"theme Icons\";
+    }
+    
+    @mixin div-theme--intl {
+        // Query overlay labels
+        --group_by--content: \"Group By\";
+        --split_by--content: \"Split By\";
+    
+        // Icons
+        --inactive-column-selector--content: \"\\E835\";
+        --active-column-selector--content: \"\\E834\";
+    }
+    
+    @mixin div-theme--chart {
+        --chart-y1-label--content: \"arrow_upward\";
+        --chart-y2-label--content: \"arrow_downward\";
+        --chart-full--gradient: linear-gradient(#4d342f 0%,
+                #e4521b 22.5%,
+                #feeb65 42.5%,
+                #f0f0f0 50%,
+                #dcedc8 57.5%,
+                #42b3d5 67.5%,
+                #1a237e 100%);
+        --chart-positive--gradient: linear-gradient(#f0f0f0 0%,
+                #dcedc8 10%,
+                #42b3d5 50%,
+                #1a237e 100%);
+        --chart-negative--gradient: linear-gradient(#4d342f 0%,
+                #e4521b 50%,
+                #feeb65 90%,
+                #f0f0f0 100%);
+    }
+    
+    @mixin div-theme--openlayers {
+        --map-tile-url: \"http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png\";
+    }
+    
+    @mixin div-theme--datagrid {
+        --column-style-open-button--content: \"menu\";
+        --column-style-close-button--content: \"expand_less\";
+    
+        table::-webkit-scrollbar-thumb {
+            background-color: transparent;
+        }
+    
+        table:hover::-webkit-scrollbar-thumb {
+            background-color: #e0e4e9;
+        }
+    }";
+
+    assert_matches!(
+        parse(test_data)
+            .map(|mut tree| {
+                transformers::apply_mixin(&mut tree);
+                let mut flat = tree.flatten_tree();
+                transformers::dedupe(&mut flat);
+                flat.as_css_string()
+            })
+            .as_deref(),
+            Ok("div[theme=\"custom\"]{--button--font-size:16px;--config-button--padding:15px 8px 6px 8px;color:#161616;background-color:#f2f4f6;font-family:\"Open Sans\";--interface-monospace--font-family:\"Roboto Mono\";--button--font-family:\"theme Icons\";--group_by--content:\"Group By\";--split_by--content:\"Split By\";--inactive-column-selector--content:\"\\E835\";--active-column-selector--content:\"\\E834\";--chart-y1-label--content:\"arrow_upward\";--chart-y2-label--content:\"arrow_downward\";--chart-full--gradient:linear-gradient(#4d342f 0%, #e4521b 22.5%, #feeb65 42.5%, #f0f0f0 50%, #dcedc8 57.5%, #42b3d5 67.5%, #1a237e 100%);--chart-positive--gradient:linear-gradient(#f0f0f0 0%, #dcedc8 10%, #42b3d5 50%, #1a237e 100%);--chart-negative--gradient:linear-gradient(#4d342f 0%, #e4521b 50%, #feeb65 90%, #f0f0f0 100%);--column-style-open-button--content:\"menu\";--column-style-close-button--content:\"expand_less\";}div[theme=\"custom\"] table:-webkit-scrollbar-thumb{background-color:transparent;}div[theme=\"custom\"] table:hover:-webkit-scrollbar-thumb{background-color:#e0e4e9;}div[theme=\"custom\"]{--map-tile-url:\"http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png\";}perspective-copy-menu[theme=\"custom\"],.perspective-modal-theme{font-family:\"Open Sans\";--interface-monospace--font-family:\"Roboto Mono\";--button--font-family:\"theme Icons\";color:#161616;background-color:#f2f4f6;background-color:white;--column-style-pos-color--content:\"add\";}")
+ 
+    )
+}


### PR DESCRIPTION
Adds a `dedupe()` transform which merges sibling rulesets with identical selectors.