### PR TITLE
Fix selector merge logic to handle duplicate `id`

### DIFF
--- a/src/ast/selector/selector_term.rs
+++ b/src/ast/selector/selector_term.rs
@@ -96,15 +96,18 @@ impl<'a, T: Clone> SelectorTerm<'a, T> {
     }
 
     /// Join to another "self" selector.
+    /// TODO Joining two selectors with populated `id` fields will discard the
+    /// parent's `id`.
     pub fn join(&self, other: &SelectorTerm<'a, ()>) -> Self {
         let mut class = self.class.clone();
         let mut attribute = self.attribute.clone();
         let mut pseudo = self.pseudo.clone();
+        let id = other.id.or(self.id);
         class.append(&mut other.class.clone());
         attribute.append(&mut other.attribute.clone());
         pseudo.append(&mut other.pseudo.clone());
         SelectorTerm {
-            id: self.id,
+            id,
             class,
             tag: self.tag.clone(),
             attribute,

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -73,7 +73,7 @@ fn test_self() {
 }
 
 #[test]
-fn test_settings() {
+fn test_id_overrides_parent() {
     let complex = "
         #test {
             &#test2:before {
@@ -86,7 +86,7 @@ fn test_settings() {
         parse(complex)
             .map(|x| x.flatten_tree().as_css_string())
             .as_deref(),
-        Ok("#test:before{color:red;}")
+        Ok("#test2:before{color:red;}")
     )
 }
 
@@ -163,5 +163,26 @@ fn test_nested_order_is_preserved() {
             .map(|x| x.flatten_tree().as_css_string())
             .as_deref(),
         Ok("div{color:red;}div{color:green;}")
+    )
+}
+
+#[test]
+fn test_complex_nesting() {
+    let complex = "
+input {
+    &:before {
+        color: white;
+    }
+    &#my_id:before {
+        color: red;
+    }
+}
+    ";
+
+    assert_matches!(
+        parse(complex)
+            .map(|x| x.flatten_tree().as_css_string())
+            .as_deref(),
+        Ok("input:before{color:white;}input#my_id:before{color:red;}")
     )
 }


### PR DESCRIPTION
```css
#test {
    &#test2 {
        color: red;
    }
}
```

... now prefers the 2nd `id` (previously it used the first).    This logic is _more_ correct, but we still do not handle the case where both fields are populated.

Both fields being populated during a merge may be a warning in the future.

```css
#test2{color:red;}
```