### PR TITLE
Use AsRef<Path> instead of &str for paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,14 +15,13 @@ use procss::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod init {
-    use std::path::Path;
     use std::{env, fs};
 
     use procss::*;
 
     pub fn init() -> anyhow::Result<String> {
         let args: Vec<String> = env::args().collect();
-        let contents = fs::read_to_string(Path::new(&args[1]));
+        let contents = fs::read_to_string(&args[1]);
         let css = parse(&contents?)?.flatten_tree().as_css_string();
         Ok(css)
     }

--- a/src/transformers/apply_import.rs
+++ b/src/transformers/apply_import.rs
@@ -10,12 +10,13 @@
 // └───────────────────────────────────────────────────────────────────────────┘
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use super::filter_refs;
 use crate::ast::Ruleset::{self};
 use crate::ast::*;
 
-pub fn apply_import<'a, 'b>(assets: &'b HashMap<&str, Tree<'a>>) -> impl Fn(&mut Tree<'a>) + 'b {
+pub fn apply_import<'a, 'b>(assets: &'b HashMap<&Path, Tree<'a>>) -> impl Fn(&mut Tree<'a>) + 'b {
     |tree| {
         tree.transform(|ruleset| {
             let mut replace = None;
@@ -23,15 +24,17 @@ pub fn apply_import<'a, 'b>(assets: &'b HashMap<&str, Tree<'a>>) -> impl Fn(&mut
                 if *name == "import" {
                     if let Some(val) = val {
                         if val.starts_with('\"') {
-                            replace = assets.get(&val[1..val.len() - 1]).cloned();
+                            replace = assets.get(Path::new(&val[1..val.len() - 1])).cloned();
                             if replace.is_none() {
                                 panic!("File not found: '{}'", &val[1..val.len() - 1])
                             }
                         } else if val.starts_with("url(\"ref://") {
-                            replace = assets.get(&val[11..val.len() - 2]).cloned().map(|mut x| {
-                                filter_refs(&mut x);
-                                x
-                            });
+                            replace = assets.get(Path::new(&val[11..val.len() - 2])).cloned().map(
+                                |mut x| {
+                                    filter_refs(&mut x);
+                                    x
+                                },
+                            );
 
                             if replace.is_none() {
                                 panic!("File not found: '{}'", &val[1..val.len() - 1])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,8 +9,6 @@
 // │                                                                           │
 // └───────────────────────────────────────────────────────────────────────────┘
 
-use std::path::PathBuf;
-
 use crate::render::RenderCss;
 
 /// A wrapper around [`Vec`] which guarantees at least `N` elements.
@@ -56,8 +54,8 @@ impl<T: RenderCss, const N: usize> RenderCss for MinVec<T, N> {
 /// to the latter and join with the former.  If the latter path is not relative,
 /// return the former.  Useful for moving directory trees while retaining their
 /// relative structure to some root.
-pub fn join_paths(outdir: &str, path: &str) -> PathBuf {
-    if let Some(parent) = PathBuf::from(path).parent() {
+pub fn join_paths(outdir: &Path, path: &Path) -> PathBuf {
+    if let Some(parent) = path.parent() {
         PathBuf::from(outdir).join(parent)
     } else {
         PathBuf::from(outdir)
@@ -87,6 +85,7 @@ mod mock {
 
 #[cfg(not(feature = "iotest"))]
 pub use std::fs;
+use std::path::{Path, PathBuf};
 
 #[cfg(feature = "iotest")]
 pub use mock::{IoTestFs, MockIoTestFs as fs};

--- a/tests/apply_import.rs
+++ b/tests/apply_import.rs
@@ -14,6 +14,7 @@
 #[cfg(test)]
 use std::assert_matches::assert_matches;
 use std::collections::HashMap;
+use std::path::Path;
 
 use procss::transformers::{apply_import, apply_var};
 use procss::{parse, RenderCss};
@@ -21,7 +22,10 @@ use procss::{parse, RenderCss};
 #[test]
 fn test_apply_import() {
     let mut trees = HashMap::default();
-    trees.insert("test", parse("div.closed{color: green}").unwrap());
+    trees.insert(
+        Path::new("test"),
+        parse("div.closed{color: green}").unwrap(),
+    );
     assert_matches!(
         parse(
             "
@@ -44,7 +48,7 @@ fn test_apply_import() {
 fn test_import_ref() {
     let mut trees = HashMap::default();
     trees.insert(
-        "test",
+        Path::new("test"),
         parse("div.closed{color: ref}@green: #00FF00;").unwrap(),
     );
     assert_matches!(


### PR DESCRIPTION
Im using ProCSS in a personal project and figured it would be _real_ nice if `add_file` and `write` took `Path`s instead of `&str`s.

If this conflicts with some wasm stuff that's fine. But, this should enable people to do `add_file("test.css")` and it just works, but now they can do `add_file(my_file_path)`, and they wont have to manually convert to `str`s.

I can revert the change to `apply_import`, and manually make a `HashMap<&str, Tree<'a>>` in `fn compile`