### PR TITLE
Fix regression in transitive var import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1580,7 @@ version = "0.1.13"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
+ "console_error_panic_hook",
  "criterion",
  "js-sys",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ wasm-bindgen-cli = { version = "0.2.83", artifact = "bin" }
 wasm-opt = "0.111.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.7"
 js-sys = "0.3.60"
 serde-wasm-bindgen = "0.4.5"
 wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -95,6 +95,7 @@ impl<'a> BuildCss<'a> {
             transformers::inline_url(&srcdir.to_string_lossy())(css);
             transformers::merge_siblings(css);
             transformers::remove_mixin(css);
+            transformers::remove_var(css);
             transformers::deduplicate(css);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,4 +36,6 @@ fn main() {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn main() {}
+fn main() {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+}

--- a/src/transformers/apply_var.rs
+++ b/src/transformers/apply_var.rs
@@ -17,16 +17,10 @@ use crate::ast::*;
 pub fn apply_var<'a>(tree: &mut Tree<'a>) {
     let mut mixins: HashMap<&'a str, &'a str> = HashMap::new();
     tree.transform(|ruleset| {
-        let mut is_mixin = false;
         if let Ruleset::QualRule(QualRule(name, Some(val))) = ruleset {
             if let Some(val) = val.strip_prefix(':') {
                 mixins.insert(name, val);
-                is_mixin = true;
             }
-        }
-
-        if is_mixin {
-            *ruleset = Ruleset::QualRuleset(QualRuleset(QualRule("", None), vec![]))
         }
     });
 

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -35,6 +35,7 @@ mod flat_self;
 mod inline_url;
 mod merge_siblings;
 mod remove_mixin;
+mod remove_var;
 
 pub use self::apply_import::apply_import;
 pub use self::apply_mixin::apply_mixin;
@@ -45,3 +46,4 @@ pub(crate) use self::flat_self::flat_self;
 pub use self::inline_url::inline_url;
 pub use self::merge_siblings::merge_siblings;
 pub use self::remove_mixin::remove_mixin;
+pub use self::remove_var::remove_var;

--- a/tests/apply_var.rs
+++ b/tests/apply_var.rs
@@ -14,7 +14,7 @@
 #[cfg(test)]
 use std::assert_matches::assert_matches;
 
-use procss::transformers::apply_var;
+use procss::transformers::{apply_var, remove_var};
 use procss::{parse, RenderCss};
 
 #[test]
@@ -31,7 +31,9 @@ fn test_var() {
         )
         .map(|mut x| {
             apply_var(&mut x);
-            x.flatten_tree().as_css_string()
+            let mut flat = x.flatten_tree();
+            remove_var(&mut flat);
+            flat.as_css_string()
         })
         .as_deref(),
         Ok("div.open{color:#FF1111;}")
@@ -52,7 +54,9 @@ fn test_var_overlapping_name() {
         )
         .map(|mut x| {
             apply_var(&mut x);
-            x.flatten_tree().as_css_string()
+            let mut flat = x.flatten_tree();
+            remove_var(&mut flat);
+            flat.as_css_string()
         })
         .as_deref(),
         Ok("div.open{color:#0000FF;}")


### PR DESCRIPTION
Fix issue when a `@var` declaration is in a import-of-an-import, as opposed to a direct import.