### PR TITLE
Fix svg whitespace issue

### DIFF
--- a/src/ast/token/space.rs
+++ b/src/ast/token/space.rs
@@ -31,14 +31,30 @@ impl NeedsWhitespaceStringExt for str {
     fn needs_pre_ws(&self) -> bool {
         self.chars()
             .next()
-            .map(|x| x.is_ascii_alphanumeric() || x == '-' || x == '_' || x == '%' || x == '+')
+            .map(|x| {
+                x.is_ascii_alphanumeric()
+                    || x == '-'
+                    || x == '_'
+                    || x == '%'
+                    || x == '+'
+                    || x == '"'
+                    || x == '\''
+            })
             .unwrap_or_default()
     }
 
     fn needs_post_ws(&self) -> bool {
         self.chars()
             .last()
-            .map(|x| x.is_ascii_alphanumeric() || x == '-' || x == '_' || x == '%' || x == '+')
+            .map(|x| {
+                x.is_ascii_alphanumeric()
+                    || x == '"'
+                    || x == '\''
+                    || x == '-'
+                    || x == '_'
+                    || x == '%'
+                    || x == '+'
+            })
             .unwrap_or_default()
     }
 }
@@ -56,18 +72,6 @@ pub fn trim_whitespace(s: &str, f: &mut std::fmt::Formatter<'_>) {
         write!(f, "{}", w).unwrap();
     });
 }
-
-// pub fn trim_whitespace(s: &str, f: &mut std::fmt::Formatter<'_>) {
-//     let mut flag = false;
-//     s.split_whitespace().for_each(|w| {
-//         if flag {
-//             write!(f, " ").unwrap();
-//         }
-
-//         flag = flag || !w.is_empty();
-//         write!(f, "{}", w).unwrap();
-//     });
-// }
 
 fn parse_comment<'a, E>(input: &'a str) -> IResult<&'a str, (), E>
 where

--- a/tests/at_ruleset.rs
+++ b/tests/at_ruleset.rs
@@ -112,7 +112,7 @@ fn test_import() {
         )
         .map(|x| x.flatten_tree().as_css_string())
         .as_deref(),
-        Ok("@import\"test\";div{color:green;}")
+        Ok("@import \"test\";div{color:green;}")
     )
 }
 

--- a/tests/minify.rs
+++ b/tests/minify.rs
@@ -35,3 +35,13 @@ fn test_minify_percent_followed_by_plus() {
         Ok("div{width:calc(100% + 28px);}")
     )
 }
+
+#[test]
+fn test_minify_svg() {
+    assert_matches!(
+        parse(r#"div { background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' preserveAspectRatio='none' viewBox='0 0 100 100'><path d='M100 0 L0 100 ' stroke='black' stroke-width='1'/><path d='M0 0 L100 100 ' stroke='black' stroke-width='1'/></svg>") #8b868045; }"#)
+            .map(|x| x.as_css_string())
+            .as_deref(),
+        Ok("div{background:url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' preserveAspectRatio='none' viewBox='0 0 100 100'><path d='M100 0 L0 100 ' stroke='black' stroke-width='1'/><path d='M0 0 L100 100 ' stroke='black' stroke-width='1'/></svg>\")#8b868045;}")
+    )
+}


### PR DESCRIPTION
Fixes an issue which cause SVG embedded as URLs to be improperly minified:

`<svg width='50' height='30'>` -> `<svg width='50'height='30'>`